### PR TITLE
Add retry failed CI jobs twice

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,12 @@ default:
       else
         export DOCKER_IMAGE_TAG="${CI_COMMIT_SHORT_SHA}-beta"
       fi
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - unknown_failure
+      - api_failure
 
 stages:
   - test


### PR DESCRIPTION
This PR add pipeline functionality to retry CI job twice in case if it failed due to following reasons: 
```
      - runner_system_failure
      - unknown_failure
      - api_failure
```